### PR TITLE
correct bin property in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-    "bin": [
-        "./bin/google-chrome-open"
-    ], 
+    "bin": {
+        "google-chrome-open": "./bin/google-chrome-open"
+    },
     "description": "open/refresh url in Google Chrome", 
     "keywords": [
         "Google", 


### PR DESCRIPTION
this way, the "bin" script will be linked to from `node_modules/.bin/google-chrome-open`.